### PR TITLE
[feature] Implement CarPhoto APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     //testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    testImplementation 'junit:junit:4.13.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/qpin/domain/carphoto/controller/CarPhotoController.java
+++ b/src/main/java/org/example/qpin/domain/carphoto/controller/CarPhotoController.java
@@ -1,0 +1,35 @@
+package org.example.qpin.domain.carphoto.controller;
+
+import org.example.qpin.domain.carphoto.dto.CarPhotoRequestDto;
+import org.example.qpin.domain.carphoto.dto.CarPhotoResponseDto;
+import org.example.qpin.domain.carphoto.service.CarPhotoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/photo")
+public class CarPhotoController {
+    public final CarPhotoService carPhotoService;
+
+    @Autowired
+    public CarPhotoController(CarPhotoService carPhotoService) {
+        this.carPhotoService =  carPhotoService;
+    }
+
+    @PostMapping
+    public void saveCarPhoto(@RequestBody CarPhotoRequestDto carPhotoRequestDto) {
+        carPhotoService.saveCarPhoto(carPhotoRequestDto);
+    }
+
+    @GetMapping("/selectList")
+    public List<CarPhotoResponseDto> getCarPhotoList(@RequestParam Long memberId) {
+        return carPhotoService.getCarPhotoList(memberId);
+    }
+
+    @DeleteMapping("/remove/{photoId}")
+    public void deleteCarPhoto(@PathVariable Long photoId) {
+        carPhotoService.deleteCarPhoto(photoId);
+    }
+}

--- a/src/main/java/org/example/qpin/domain/carphoto/dto/CarPhotoRequestDto.java
+++ b/src/main/java/org/example/qpin/domain/carphoto/dto/CarPhotoRequestDto.java
@@ -1,0 +1,16 @@
+package org.example.qpin.domain.carphoto.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CarPhotoRequestDto {
+    private Long userId;
+    private String carPhotoUrl;
+    private String parkingArea;
+}

--- a/src/main/java/org/example/qpin/domain/carphoto/dto/CarPhotoResponseDto.java
+++ b/src/main/java/org/example/qpin/domain/carphoto/dto/CarPhotoResponseDto.java
@@ -1,0 +1,16 @@
+package org.example.qpin.domain.carphoto.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CarPhotoResponseDto {
+    private Long carPhotoId;
+    private String carPhotoUrl;
+    private String parkingArea;
+}

--- a/src/main/java/org/example/qpin/domain/carphoto/entity/CarPhoto.java
+++ b/src/main/java/org/example/qpin/domain/carphoto/entity/CarPhoto.java
@@ -16,8 +16,11 @@ public class CarPhoto extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long carPhotoId;
 
+    @Column(nullable = false)
+    private String carPhotoUrl;
+
     @Column(length = 50, nullable = false)
-    private String ParkingArea;
+    private String parkingArea;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/org/example/qpin/domain/carphoto/repository/CarPhotoRepository.java
+++ b/src/main/java/org/example/qpin/domain/carphoto/repository/CarPhotoRepository.java
@@ -1,0 +1,10 @@
+package org.example.qpin.domain.carphoto.repository;
+
+import org.example.qpin.domain.carphoto.entity.CarPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CarPhotoRepository extends JpaRepository<CarPhoto, Long> {
+    List<CarPhoto> findByMember_MemberId(Long memberId);
+}

--- a/src/main/java/org/example/qpin/domain/carphoto/service/CarPhotoService.java
+++ b/src/main/java/org/example/qpin/domain/carphoto/service/CarPhotoService.java
@@ -1,0 +1,12 @@
+package org.example.qpin.domain.carphoto.service;
+
+import org.example.qpin.domain.carphoto.dto.CarPhotoRequestDto;
+import org.example.qpin.domain.carphoto.dto.CarPhotoResponseDto;
+
+import java.util.List;
+
+public interface CarPhotoService {
+    void saveCarPhoto(CarPhotoRequestDto carPhotoRequestDto);
+    List<CarPhotoResponseDto> getCarPhotoList(Long memberId);
+    void deleteCarPhoto(Long photoId);
+}

--- a/src/main/java/org/example/qpin/domain/carphoto/service/CarPhotoServiceImpl.java
+++ b/src/main/java/org/example/qpin/domain/carphoto/service/CarPhotoServiceImpl.java
@@ -1,0 +1,57 @@
+package org.example.qpin.domain.carphoto.service;
+
+import org.example.qpin.domain.carphoto.dto.CarPhotoRequestDto;
+import org.example.qpin.domain.carphoto.dto.CarPhotoResponseDto;
+import org.example.qpin.domain.carphoto.entity.CarPhoto;
+import org.example.qpin.domain.carphoto.repository.CarPhotoRepository;
+import org.example.qpin.domain.member.entity.Member;
+import org.example.qpin.domain.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CarPhotoServiceImpl implements CarPhotoService {
+
+    private final CarPhotoRepository carPhotoRepository;
+    private final MemberRepository memberRepository;
+
+    @Autowired
+    public CarPhotoServiceImpl(CarPhotoRepository carPhotoRepository, MemberRepository memberRepository) {
+        this.carPhotoRepository = carPhotoRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @Override
+    public void saveCarPhoto(CarPhotoRequestDto carPhotoRequestDto) {
+        Member member = memberRepository.findById(carPhotoRequestDto.getUserId())
+                .orElseThrow(() -> new RuntimeException("Member Not Found for id"));
+        CarPhoto carPhoto = CarPhoto.builder()
+                .carPhotoUrl(carPhotoRequestDto.getCarPhotoUrl())
+                .parkingArea(carPhotoRequestDto.getParkingArea())
+                .member(member)
+                .build();
+
+        carPhotoRepository.save(carPhoto);
+    }
+
+    @Override
+    public List<CarPhotoResponseDto> getCarPhotoList(Long memberId) {
+        List<CarPhoto> carPhotos = carPhotoRepository.findByMember_MemberId(memberId);
+
+        return carPhotos.stream()
+                .map(carPhoto -> CarPhotoResponseDto.builder()
+                        .carPhotoId(carPhoto.getCarPhotoId())
+                        .carPhotoUrl(carPhoto.getCarPhotoUrl())
+                        .parkingArea(carPhoto.getParkingArea())
+                                .build())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void deleteCarPhoto(Long photoId) {
+        carPhotoRepository.deleteById(photoId);
+    }
+}

--- a/src/main/java/org/example/qpin/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/example/qpin/domain/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package org.example.qpin.domain.member.repository;
+
+import org.example.qpin.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}


### PR DESCRIPTION
## 📌 Issue
> [Feature] Create APIs for Photo Domain
> close #5 

## 📌 PR Description
> 차량 사진 관련 저장, 리스트, 삭제를 위한 API 엔드포인트를 추가했습니다.
- `POST /photo`: 차량 사진을 저장합니다.
- `GET /photo/selectList`: 차량 사진 저장 리스트를 조회합니다.
- `DELETE /photo/remove/{photoId}`: 저장된 차량 사진을 삭제합니다.

## 📝 Progress
`domain/carphoto`
- controller/CarPhotoController
- dto/CarPhotoRequestDto
- dto/CarPhotoResponseDto
- repository/CarPhotoRepository
- service/CarPhotoService
- service/CarPhotoServiceImpl

`domain/member`
- repository/MemberRepository

## 📩 API Test 
- `POST /photo`
![image](https://github.com/user-attachments/assets/60438020-1327-47f3-a297-ce94f4efdb37)
- `GET /photo/selectList`
![image](https://github.com/user-attachments/assets/621d2400-ddc6-4779-944b-2d1c55493748)
- `DELETE /photo/remove/{photoId}`
![image](https://github.com/user-attachments/assets/28cc7451-389e-43c0-819f-77949a12404c)
## 💬 ETC
저의 작업 범위가 아닌 Member에 Repository를 생성했습니다.
혹시나 conflict가 발생하면 그때 해결하면 괜찮을 듯 합니다!