### PR TITLE
[Feature] 간편 주차 주차장 정보 및 주차 상태 변경 API 구현

### DIFF
--- a/src/main/java/org/example/qpin/domain/parking/controller/ParkingController.java
+++ b/src/main/java/org/example/qpin/domain/parking/controller/ParkingController.java
@@ -26,7 +26,7 @@ public class ParkingController {
     public ResponseEntity<List<ParkingSearchResDto>> findParkingNearby(@RequestBody ParkingSearchReqDto parkingSearchReqDto) throws ParseException {
 
         double latitude=parkingSearchReqDto.getLatitude();
-        double longitude=parkingSearchReqDto.getLongitude();
+        double longitude=parkingSearchReqDto.getLongtitude();
         double distance=parkingSearchReqDto.getDistance();
         String regionCode=parkingSearchReqDto.getRegionCode();
         return ResponseEntity.status(HttpStatus.OK).body(parkingService.findParkingNearby(latitude, longitude, distance,regionCode ));

--- a/src/main/java/org/example/qpin/domain/parking/controller/ParkingController.java
+++ b/src/main/java/org/example/qpin/domain/parking/controller/ParkingController.java
@@ -39,4 +39,12 @@ public class ParkingController {
         parkingService.postParking(memberId, parkingAreaId);
         return new CommonResponse<>(ResponseCode.SUCCESS);
     }
+
+    // [Delete] 주차하기 버튼 해제
+    @DeleteMapping("/parking/{parkingAreaId}/{memberId}")
+    @ResponseBody
+    public CommonResponse<?> deleteParking(@PathVariable("memberId") Long memberId, @PathVariable("parkingAreaId") String parkingAreaId) {
+        parkingService.deleteParking(memberId, parkingAreaId);
+        return new CommonResponse<>(ResponseCode.SUCCESS);
+    }
 }

--- a/src/main/java/org/example/qpin/domain/parking/controller/ParkingController.java
+++ b/src/main/java/org/example/qpin/domain/parking/controller/ParkingController.java
@@ -47,4 +47,10 @@ public class ParkingController {
         parkingService.deleteParking(memberId, parkingAreaId);
         return new CommonResponse<>(ResponseCode.SUCCESS);
     }
+
+    // [Get] 간편 주차 주차장 정보
+    @GetMapping("/parking/select/{parkingAreaId}/{memberId}")
+    public CommonResponse<?> parkingInfo(@PathVariable("memberId") Long memberId, @PathVariable("parkingAreaId") String parkingAreaId) {
+        return new CommonResponse<>(ResponseCode.SUCCESS, parkingService.getParkingInfo(memberId, parkingAreaId));
+    }
 }

--- a/src/main/java/org/example/qpin/domain/parking/controller/ParkingController.java
+++ b/src/main/java/org/example/qpin/domain/parking/controller/ParkingController.java
@@ -4,12 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.example.qpin.domain.parking.dto.ParkingSearchReqDto;
 import org.example.qpin.domain.parking.dto.ParkingSearchResDto;
 import org.example.qpin.domain.parking.service.ParkingService;
+import org.example.qpin.global.common.response.CommonResponse;
+import org.example.qpin.global.common.response.ResponseCode;
 import org.json.simple.parser.ParseException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -30,5 +30,13 @@ public class ParkingController {
         double distance=parkingSearchReqDto.getDistance();
         String regionCode=parkingSearchReqDto.getRegionCode();
         return ResponseEntity.status(HttpStatus.OK).body(parkingService.findParkingNearby(latitude, longitude, distance,regionCode ));
+    }
+
+    // [Post] 주차하기 버튼
+    @PostMapping("/parking/{parkingAreaId}/{memberId}")
+    @ResponseBody
+    public CommonResponse<?> parking(@PathVariable("memberId") Long memberId, @PathVariable("parkingAreaId") String parkingAreaId) {
+        parkingService.postParking(memberId, parkingAreaId);
+        return new CommonResponse<>(ResponseCode.SUCCESS);
     }
 }

--- a/src/main/java/org/example/qpin/domain/parking/dto/ParkingInfoResDto.java
+++ b/src/main/java/org/example/qpin/domain/parking/dto/ParkingInfoResDto.java
@@ -1,0 +1,21 @@
+package org.example.qpin.domain.parking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ParkingInfoResDto {
+
+    private boolean parkingStatus;
+    private boolean scrapStatus;
+    private LocalDateTime parkingDate;
+    private int parkingTime;
+
+}

--- a/src/main/java/org/example/qpin/domain/parking/dto/ParkingSearchReqDto.java
+++ b/src/main/java/org/example/qpin/domain/parking/dto/ParkingSearchReqDto.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Builder
 public class ParkingSearchReqDto {
     private double latitude;
-    private double longitude;
+    private double longtitude;
     private double distance;
     private String regionCode; //지역코드 5자리 문자열
 

--- a/src/main/java/org/example/qpin/domain/parking/dto/ParkingSearchResDto.java
+++ b/src/main/java/org/example/qpin/domain/parking/dto/ParkingSearchResDto.java
@@ -8,16 +8,20 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ParkingSearchResDto {
-    
-    private double longitude; //경도
 
+    private double longtitude; //경도
     private double latitude; //위도
-
     private String address; //도로명주소
-
     private String name; //주차장명
-
     private String price; //무료,유료
-
     private Long parkId;
+    private double parkingDistance;
+
+    private String weekStartTime;
+    private String weekEndTime;
+    private String SaturdayStartTime;
+    private String SaturdayEndTime;
+    private String HolidayStartTime;
+    private String HolidayEndTime;
+
 }

--- a/src/main/java/org/example/qpin/domain/parking/service/ParkingService.java
+++ b/src/main/java/org/example/qpin/domain/parking/service/ParkingService.java
@@ -38,13 +38,13 @@ public class ParkingService {
         return memberRepository.findById(memberId).orElseThrow();
     }
 
-    //latitude: 위도, longitude: 경도
+    //latitude: 위도, longtitude: 경도
 
     /**
      * 위도와 경도, 거리, 지역 코드를 입력하면
      * 해당 위치로부터 입력한 거리 이내의 주차장의 정보를 반환함.
      */
-    public List<ParkingSearchResDto> findParkingNearby(double mylatitude, double mylongitude, double distance, String regionCode) throws ParseException {
+    public List<ParkingSearchResDto> findParkingNearby(double mylatitude, double mylongtitude, double distance, String regionCode) throws ParseException {
         final int page=1;
         final int perPage=150;
         final String DECODING_KEY="yncOh3M5FtqbW1UwmQmkBKpkkyYqZMj1FddwHcalnFzVCFtnlwkDOhRPFHkhnJPRKYy4scMVfbJMxn954Ym/Eg=="; //키 암호화 필요
@@ -77,18 +77,27 @@ public class ParkingService {
         for(int i=0; i<dataList.size(); i++){
             JSONObject data=(JSONObject) dataList.get(i); //해당되는 주차장이 없으면 null예외처리 해야함. 500에러 발생.
             double latitude=Double.parseDouble((String) data.get("위도"));
-            double longitude=Double.parseDouble((String) data.get("경도"));
+            double longtitude=Double.parseDouble((String) data.get("경도"));
             /**
              * 설정한 거리보다 가까운 주차장만 리스트에 추가
              */
-            if(distance>=distance(mylatitude, mylongitude, latitude, longitude)){
-                ParkingSearchResDto parkingSearchResDto =new ParkingSearchResDto().builder()
+
+            double parkingDistance = distance(mylatitude, mylongtitude, latitude, longtitude);
+            if(distance>=parkingDistance){
+                ParkingSearchResDto parkingSearchResDto = new ParkingSearchResDto().builder()
                         .latitude(latitude)
-                        .longitude(longitude)
+                        .longtitude(longtitude)
                         .parkId(Long.parseLong((String) data.get("주차장관리번호")))
                         .name((String) data.get("주차장명"))
                         .address((String) data.get("주차장도로명주소"))
                         .price((String) data.get("요금정보"))
+                        .parkingDistance(parkingDistance)
+                        .weekStartTime((String) data.get("평일운영시작시각"))
+                        .weekEndTime((String) data.get("평일운영종료시각"))
+                        .SaturdayStartTime((String) data.get("토요일운영시작시각"))
+                        .SaturdayEndTime((String) data.get("토요일운영종료시각"))
+                        .HolidayStartTime((String) data.get("공휴일운영시작시각"))
+                        .HolidayEndTime((String) data.get("공휴일운영종료시각"))
                         .build();
                 parkingSearchResDtoList.add(parkingSearchResDto);
             }

--- a/src/main/java/org/example/qpin/domain/parking/service/ParkingService.java
+++ b/src/main/java/org/example/qpin/domain/parking/service/ParkingService.java
@@ -1,7 +1,11 @@
 package org.example.qpin.domain.parking.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.qpin.domain.member.entity.Member;
 import org.example.qpin.domain.parking.dto.ParkingSearchResDto;
+import org.example.qpin.domain.parking.entity.Parking;
+import org.example.qpin.domain.scrap.entity.Scrap;
+import org.example.qpin.global.common.repository.MemberRepository;
 import org.example.qpin.global.common.repository.ParkingRepository;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -21,6 +25,11 @@ import java.util.List;
 public class ParkingService {
 
     private final ParkingRepository parkingRepository;
+    private final MemberRepository memberRepository;
+
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow();
+    }
 
     //latitude: 위도, longitude: 경도
 
@@ -101,6 +110,19 @@ public class ParkingService {
     //radian(라디안)을 10진수로 변환
     private static double rad2deg(double rad){
         return (rad * 180 / Math.PI);
+    }
+
+
+    public void postParking(Long memberId, String parkingAreaId) {
+        Member member = findMemberById(memberId);
+
+        Parking newParking = Parking.builder()
+                .member(member)
+                .parkingAreaId(parkingAreaId)
+                .build();
+
+        parkingRepository.save(newParking);
+        return;
     }
 
 }

--- a/src/main/java/org/example/qpin/domain/parking/service/ParkingService.java
+++ b/src/main/java/org/example/qpin/domain/parking/service/ParkingService.java
@@ -7,6 +7,7 @@ import org.example.qpin.domain.parking.entity.Parking;
 import org.example.qpin.domain.scrap.entity.Scrap;
 import org.example.qpin.global.common.repository.MemberRepository;
 import org.example.qpin.global.common.repository.ParkingRepository;
+import org.example.qpin.global.exception.BadRequestException;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -19,6 +20,9 @@ import org.springframework.web.util.DefaultUriBuilderFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.example.qpin.global.exception.ExceptionCode.NOT_FOUND_MEMBER_ID;
+import static org.example.qpin.global.exception.ExceptionCode.NOT_FOUND_PARKING;
 
 @Service
 @RequiredArgsConstructor
@@ -122,6 +126,16 @@ public class ParkingService {
                 .build();
 
         parkingRepository.save(newParking);
+        return;
+    }
+
+    public void deleteParking(Long memberId, String parkingAreaId) {
+        Member member = findMemberById(memberId);
+
+        Parking parking = parkingRepository.findParkingByParkingAreaIdAndMember(parkingAreaId, member)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_PARKING));
+
+        parkingRepository.delete(parking);
         return;
     }
 

--- a/src/main/java/org/example/qpin/global/common/repository/ParkingRepository.java
+++ b/src/main/java/org/example/qpin/global/common/repository/ParkingRepository.java
@@ -1,7 +1,12 @@
 package org.example.qpin.global.common.repository;
 
+import org.example.qpin.domain.member.entity.Member;
 import org.example.qpin.domain.parking.entity.Parking;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ParkingRepository extends JpaRepository<Parking, Long> {
+
+    Optional<Parking> findParkingByParkingAreaIdAndMember(String parkingAreaId, Member member);
 }

--- a/src/main/java/org/example/qpin/global/common/repository/ScrapRepository.java
+++ b/src/main/java/org/example/qpin/global/common/repository/ScrapRepository.java
@@ -1,10 +1,14 @@
 package org.example.qpin.global.common.repository;
 
+import org.example.qpin.domain.member.entity.Member;
+import org.example.qpin.domain.parking.entity.Parking;
 import org.example.qpin.domain.scrap.entity.Scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+
+    Optional<Scrap> findScrapByParkIdAndMember(String parkId, Member member);
 
 }

--- a/src/main/java/org/example/qpin/global/exception/ExceptionCode.java
+++ b/src/main/java/org/example/qpin/global/exception/ExceptionCode.java
@@ -25,6 +25,9 @@ public enum ExceptionCode {
     FAIL_IMAGE_NAME_HASH(5102, "이미지 이름을 해싱하는 데 실패했습니다."),
     INVALID_IMAGE(5103, "올바르지 않은 이미지 파일입니다."),
 
+    // 주차 에러
+    NOT_FOUND_PARKING(6001, "요청한 주차ID와 멤버ID에 해당하는 정보가 존재하지 않습니다."),
+
     INVALID_USER_NAME(8001, "존재하지 않는 사용자입니다."),
     INVALID_PASSWORD(8002, "비밀번호가 일치하지 않습니다."),
     NULL_ADMIN_AUTHORITY(8101, "잘못된 관리자 권한입니다."),


### PR DESCRIPTION
## 📌 Issue

> #14

## 📝 Progress
- `주차하기 버튼` API 구현
- `주차하기 버튼 해제` API 구현
- `간편 주차 주차장 정보` API 구현
- `주변 주차장 조회` 응답 값 추가 : 간편 주차장 정보에서 값을 가져올 경우, 10000개 이상의 데이터를 모두 조회한 다음 parkId를 다시 찾아야 하므로 주변 주차장 조회에서 필요한 모든 데이터를 가져온 후 재활용하는 것이 더 좋다고 판단. 응답값으로 주차장 관련 정보를 추가함 (현재 위치로부터 주차장 까지의 거리와, 주차장 이용 시간 정보 추가)
- 주변 주차장 조회 오탈자 수정

## 📩 API Test 
- `주차하기 버튼` API 구현
![image](https://github.com/user-attachments/assets/cd78c208-ee68-4b06-9c9a-a36ea0d87619)

- `주차하기 버튼 해제` API 구현
![image](https://github.com/user-attachments/assets/e2e9053c-b697-4b8e-a741-5be63dfefe7f)

- `간편 주차 주차장 정보` API 구현
![image](https://github.com/user-attachments/assets/043b1b00-8cf7-46d1-9b39-9b3750c74d8f)

- `주변 주차장 조회` 응답 값 추가 
![image](https://github.com/user-attachments/assets/3d192a89-7ad1-407c-b2de-61e8d0fc5dce)


## 💬 ETC
- AccessToken 가져오는 부분 향후 코드 수정 필요